### PR TITLE
feat: implement agent discovery standards (RFC 8288, RFC 9727, WebMCP, MCP Server Card, and more)

### DIFF
--- a/app/.well-known/api-catalog/route.js
+++ b/app/.well-known/api-catalog/route.js
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+
+const BASE = 'https://www.pratyum.xyz';
+
+const catalog = {
+  linkset: [
+    {
+      anchor: `${BASE}/feed.xml`,
+      'service-doc': [{ href: `${BASE}/feed.xml`, type: 'application/rss+xml' }],
+      describedby: [{ href: `${BASE}/feed.xml`, type: 'application/rss+xml' }],
+    },
+    {
+      anchor: BASE,
+      'service-doc': [{ href: `${BASE}/about` }],
+      status: [{ href: `${BASE}/api/health` }],
+    },
+  ],
+};
+
+export async function GET() {
+  return new NextResponse(JSON.stringify(catalog, null, 2), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/linkset+json',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}

--- a/app/.well-known/oauth-authorization-server/route.js
+++ b/app/.well-known/oauth-authorization-server/route.js
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+
+const BASE = 'https://www.pratyum.xyz';
+
+const metadata = {
+  issuer: BASE,
+  authorization_endpoint: `${BASE}/oauth/authorize`,
+  token_endpoint: `${BASE}/oauth/token`,
+  jwks_uri: `${BASE}/.well-known/jwks.json`,
+  response_types_supported: ['code'],
+  grant_types_supported: ['authorization_code'],
+  scopes_supported: ['openid', 'profile'],
+  token_endpoint_auth_methods_supported: ['none'],
+  service_documentation: `${BASE}/about`,
+
+  // agent_auth block per Auth.md spec (https://github.com/workos/auth.md)
+  agent_auth: {
+    register_uri: null,
+    identity_types: ['anonymous'],
+    credential_types: ['none'],
+    claim_uri: null,
+    revocation_uri: null,
+    note: 'All public endpoints are accessible without registration or credentials.',
+  },
+};
+
+export async function GET() {
+  return NextResponse.json(metadata, {
+    headers: {
+      'Cache-Control': 'public, max-age=86400',
+    },
+  });
+}

--- a/app/.well-known/oauth-protected-resource/route.js
+++ b/app/.well-known/oauth-protected-resource/route.js
@@ -4,7 +4,7 @@ const BASE = 'https://www.pratyum.xyz';
 
 const metadata = {
   resource: BASE,
-  authorization_servers: [`${BASE}/.well-known/openid-configuration`],
+  authorization_servers: [BASE],
   scopes_supported: ['openid', 'profile'],
   bearer_methods_supported: ['header'],
   resource_documentation: `${BASE}/about`,

--- a/app/.well-known/oauth-protected-resource/route.js
+++ b/app/.well-known/oauth-protected-resource/route.js
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+
+const BASE = 'https://www.pratyum.xyz';
+
+const metadata = {
+  resource: BASE,
+  authorization_servers: [`${BASE}/.well-known/openid-configuration`],
+  scopes_supported: ['openid', 'profile'],
+  bearer_methods_supported: ['header'],
+  resource_documentation: `${BASE}/about`,
+};
+
+export async function GET() {
+  return NextResponse.json(metadata, {
+    headers: {
+      'Cache-Control': 'public, max-age=86400',
+    },
+  });
+}

--- a/app/.well-known/openid-configuration/route.js
+++ b/app/.well-known/openid-configuration/route.js
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+
+const BASE = 'https://www.pratyum.xyz';
+
+const discovery = {
+  issuer: BASE,
+  authorization_endpoint: `${BASE}/oauth/authorize`,
+  token_endpoint: `${BASE}/oauth/token`,
+  jwks_uri: `${BASE}/.well-known/jwks.json`,
+  response_types_supported: ['code'],
+  grant_types_supported: ['authorization_code'],
+  subject_types_supported: ['public'],
+  id_token_signing_alg_values_supported: ['RS256'],
+  scopes_supported: ['openid', 'profile'],
+  claims_supported: ['sub', 'name', 'email'],
+  service_documentation: `${BASE}/about`,
+};
+
+export async function GET() {
+  return NextResponse.json(discovery, {
+    headers: {
+      'Cache-Control': 'public, max-age=86400',
+    },
+  });
+}

--- a/app/api/health/route.js
+++ b/app/api/health/route.js
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({ status: 'ok' });
+}

--- a/app/api/markdown/route.js
+++ b/app/api/markdown/route.js
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+
+const PAGE_MARKDOWN = {
+  '/': `# Pratyum Jagannath — Full Stack Developer & Web3 Enthusiast
+
+**URL:** https://www.pratyum.xyz
+**Role:** Full Stack Developer
+**Skills:** React, Next.js, Node.js, Python, Django, Web3, JavaScript
+
+## About
+
+Pratyum Jagannath is a Full Stack Developer specialized in React, Node.js, Python, and Web3 technologies with experience in building innovative applications.
+
+## Links
+
+- [Portfolio](https://www.pratyum.xyz)
+- [GitHub](https://github.com/pratyum)
+- [LinkedIn](https://linkedin.com/in/pratyumjagannath)
+- [Cases / Projects](https://www.pratyum.xyz/cases)
+- [About](https://www.pratyum.xyz/about)
+- [Contact](https://www.pratyum.xyz/contact)
+
+## Agent Discovery
+
+- [API Catalog](https://www.pratyum.xyz/.well-known/api-catalog)
+- [MCP Server Card](https://www.pratyum.xyz/.well-known/mcp/server-card.json)
+- [Agent Skills Index](https://www.pratyum.xyz/.well-known/agent-skills/index.json)
+- [Auth Info](https://www.pratyum.xyz/auth.md)
+`,
+  '/about': `# About — Pratyum Jagannath
+
+Full Stack Developer & Web3 Enthusiast based in Singapore.
+Alumnus of Nanyang Technological University.
+
+**URL:** https://www.pratyum.xyz/about
+`,
+  '/cases': `# Projects & Case Studies — Pratyum Jagannath
+
+A curated selection of projects across web3, SaaS, and full-stack development.
+
+**URL:** https://www.pratyum.xyz/cases
+`,
+  '/contact': `# Contact — Pratyum Jagannath
+
+Reach out via [LinkedIn](https://linkedin.com/in/pratyumjagannath) or the contact form at https://www.pratyum.xyz/contact.
+`,
+};
+
+export async function GET(request) {
+  const { searchParams } = new URL(request.url);
+  const path = searchParams.get('path') || '/';
+  const content = PAGE_MARKDOWN[path] ?? PAGE_MARKDOWN['/'];
+
+  return new NextResponse(content, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Vary': 'Accept',
+    },
+  });
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,4 +1,5 @@
 import Layout from '@/components/Layout';
+import WebMCP from '@/components/WebMCP';
 import { AppContextProvider } from '@/context/AppContext';
 import '@/styles/globals.css';
 import { Analytics } from '@vercel/analytics/next';
@@ -66,6 +67,7 @@ export default function RootLayout({ children }) {
           </Layout>
         </AppContextProvider>
         <Analytics debug={isDev} mode={isDev ? 'development' : 'production'} />
+        <WebMCP />
       </body>
     </html>
   );

--- a/components/WebMCP.js
+++ b/components/WebMCP.js
@@ -1,65 +1,80 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
-const tools = [
-  {
-    name: 'get_portfolio_summary',
-    description: 'Returns a brief summary of Pratyum Jagannath\'s portfolio including skills, roles, and links.',
-    inputSchema: { type: 'object', properties: {}, required: [] },
-    execute: async () => ({
-      name: 'Pratyum Jagannath',
-      role: 'Full Stack Developer & Web3 Enthusiast',
-      skills: ['React', 'Next.js', 'Node.js', 'Python', 'Django', 'Web3'],
-      links: {
-        portfolio: 'https://www.pratyum.xyz',
-        cases: 'https://www.pratyum.xyz/cases',
-        about: 'https://www.pratyum.xyz/about',
-        contact: 'https://www.pratyum.xyz/contact',
-        github: 'https://github.com/pratyum',
-        linkedin: 'https://linkedin.com/in/pratyumjagannath',
+export default function WebMCP() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const mc = navigator.modelContext;
+    if (!mc || typeof mc.provideContext !== 'function') return;
+    if (mc.__webmcp_tools_registered) return;
+
+    const tools = [
+      {
+        name: 'get_portfolio_summary',
+        description: "Returns a brief summary of Pratyum Jagannath's portfolio including skills, roles, and links.",
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        execute: async () => ({
+          name: 'Pratyum Jagannath',
+          role: 'Full Stack Developer & Web3 Enthusiast',
+          skills: ['React', 'Next.js', 'Node.js', 'Python', 'Django', 'Web3'],
+          links: {
+            portfolio: 'https://www.pratyum.xyz',
+            cases: 'https://www.pratyum.xyz/cases',
+            about: 'https://www.pratyum.xyz/about',
+            contact: 'https://www.pratyum.xyz/contact',
+            github: 'https://github.com/pratyum',
+            linkedin: 'https://linkedin.com/in/pratyumjagannath',
+          },
+        }),
       },
-    }),
-  },
-  {
-    name: 'navigate_to',
-    description: 'Navigate the browser to a named section of the portfolio.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        section: {
-          type: 'string',
-          enum: ['home', 'about', 'cases', 'contact'],
-          description: 'The portfolio section to navigate to.',
+      {
+        name: 'navigate_to',
+        description: 'Navigate the browser to a named section of the portfolio.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            section: {
+              type: 'string',
+              enum: ['home', 'about', 'cases', 'contact'],
+              description: 'The portfolio section to navigate to.',
+            },
+          },
+          required: ['section'],
+        },
+        execute: async ({ section }) => {
+          const routes = { home: '/', about: '/about', cases: '/cases', contact: '/contact' };
+          const path = routes[section] ?? '/';
+          router.push(path);
+          return { navigated: true, path };
         },
       },
-      required: ['section'],
-    },
-    execute: async ({ section }) => {
-      const routes = { home: '/', about: '/about', cases: '/cases', contact: '/contact' };
-      const path = routes[section] ?? '/';
-      window.location.href = path;
-      return { navigated: true, path };
-    },
-  },
-  {
-    name: 'get_contact_info',
-    description: 'Returns contact information and social profile links for Pratyum Jagannath.',
-    inputSchema: { type: 'object', properties: {}, required: [] },
-    execute: async () => ({
-      github: 'https://github.com/pratyum',
-      linkedin: 'https://linkedin.com/in/pratyumjagannath',
-      twitter: 'https://twitter.com/pratyumjagan',
-      contact_form: 'https://www.pratyum.xyz/contact',
-    }),
-  },
-];
+      {
+        name: 'get_contact_info',
+        description: 'Returns contact information and social profile links for Pratyum Jagannath.',
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        execute: async () => ({
+          github: 'https://github.com/pratyum',
+          linkedin: 'https://linkedin.com/in/pratyumjagannath',
+          twitter: 'https://twitter.com/pratyumjagan',
+          contact_form: 'https://www.pratyum.xyz/contact',
+        }),
+      },
+    ];
 
-export default function WebMCP() {
-  useEffect(() => {
-    if (typeof navigator === 'undefined' || !navigator.modelContext) return;
-    navigator.modelContext.provideContext({ tools }).catch(() => {});
-  }, []);
+    mc.provideContext({ tools })
+      .then(() => { mc.__webmcp_tools_registered = true; })
+      .catch((err) => { console.error('[WebMCP] provideContext failed:', err); });
+
+    return () => {
+      if (typeof mc.unregisterTool === 'function') {
+        tools.forEach(({ name }) => mc.unregisterTool(name));
+      }
+      delete mc.__webmcp_tools_registered;
+    };
+  }, [router]);
 
   return null;
 }

--- a/components/WebMCP.js
+++ b/components/WebMCP.js
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const tools = [
+  {
+    name: 'get_portfolio_summary',
+    description: 'Returns a brief summary of Pratyum Jagannath\'s portfolio including skills, roles, and links.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    execute: async () => ({
+      name: 'Pratyum Jagannath',
+      role: 'Full Stack Developer & Web3 Enthusiast',
+      skills: ['React', 'Next.js', 'Node.js', 'Python', 'Django', 'Web3'],
+      links: {
+        portfolio: 'https://www.pratyum.xyz',
+        cases: 'https://www.pratyum.xyz/cases',
+        about: 'https://www.pratyum.xyz/about',
+        contact: 'https://www.pratyum.xyz/contact',
+        github: 'https://github.com/pratyum',
+        linkedin: 'https://linkedin.com/in/pratyumjagannath',
+      },
+    }),
+  },
+  {
+    name: 'navigate_to',
+    description: 'Navigate the browser to a named section of the portfolio.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        section: {
+          type: 'string',
+          enum: ['home', 'about', 'cases', 'contact'],
+          description: 'The portfolio section to navigate to.',
+        },
+      },
+      required: ['section'],
+    },
+    execute: async ({ section }) => {
+      const routes = { home: '/', about: '/about', cases: '/cases', contact: '/contact' };
+      const path = routes[section] ?? '/';
+      window.location.href = path;
+      return { navigated: true, path };
+    },
+  },
+  {
+    name: 'get_contact_info',
+    description: 'Returns contact information and social profile links for Pratyum Jagannath.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    execute: async () => ({
+      github: 'https://github.com/pratyum',
+      linkedin: 'https://linkedin.com/in/pratyumjagannath',
+      twitter: 'https://twitter.com/pratyumjagan',
+      contact_form: 'https://www.pratyum.xyz/contact',
+    }),
+  },
+];
+
+export default function WebMCP() {
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !navigator.modelContext) return;
+    navigator.modelContext.provideContext({ tools }).catch(() => {});
+  }, []);
+
+  return null;
+}

--- a/config/dns-aid.json
+++ b/config/dns-aid.json
@@ -1,0 +1,32 @@
+{
+  "$comment": "DNS for AI Discovery (DNS-AID) configuration reference. These records must be published via your DNS provider. See https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/",
+  "domain": "pratyum.xyz",
+  "records": [
+    {
+      "name": "_index._agents.pratyum.xyz",
+      "type": "HTTPS",
+      "priority": 1,
+      "target": "pratyum.xyz",
+      "params": {
+        "alpn": "h2,h3",
+        "endpoint": "/.well-known/agent-skills/index.json"
+      },
+      "description": "Primary agent skills discovery index"
+    },
+    {
+      "name": "_a2a._agents.pratyum.xyz",
+      "type": "HTTPS",
+      "priority": 1,
+      "target": "pratyum.xyz",
+      "params": {
+        "alpn": "h2,h3",
+        "endpoint": "/.well-known/mcp/server-card.json"
+      },
+      "description": "Agent-to-agent MCP server card endpoint"
+    }
+  ],
+  "dnssec": {
+    "required": true,
+    "note": "Sign the _agents zone with DNSSEC so validating resolvers return authenticated data."
+  }
+}

--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+
+const MARKDOWN_ROUTES = new Set(['/', '/about', '/cases', '/contact']);
+
+export function middleware(request) {
+  const accept = request.headers.get('accept') ?? '';
+  const { pathname } = request.nextUrl;
+
+  if (accept.includes('text/markdown') && MARKDOWN_ROUTES.has(pathname)) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/api/markdown';
+    url.searchParams.set('path', pathname);
+    return NextResponse.rewrite(url);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/', '/about', '/cases', '/contact'],
+};

--- a/middleware.js
+++ b/middleware.js
@@ -1,12 +1,10 @@
 import { NextResponse } from 'next/server';
 
-const MARKDOWN_ROUTES = new Set(['/', '/about', '/cases', '/contact']);
-
 export function middleware(request) {
   const accept = request.headers.get('accept') ?? '';
   const { pathname } = request.nextUrl;
 
-  if (accept.includes('text/markdown') && MARKDOWN_ROUTES.has(pathname)) {
+  if (accept.includes('text/markdown')) {
     const url = request.nextUrl.clone();
     url.pathname = '/api/markdown';
     url.searchParams.set('path', pathname);

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -32,6 +32,20 @@ const nextConfig = {
   headers: async () => {
     return [
       {
+        source: '/',
+        headers: [
+          {
+            key: 'Link',
+            value: [
+              '</.well-known/api-catalog>; rel="api-catalog"',
+              '</.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/skills-index"',
+              '</.well-known/mcp/server-card.json>; rel="https://modelcontextprotocol.io/rel/server-card"',
+              '</auth.md>; rel="auth-info"',
+            ].join(', '),
+          },
+        ],
+      },
+      {
         source: '/(.*)',
         headers: [
           {

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -6,28 +6,28 @@
       "type": "read",
       "description": "Browse Pratyum Jagannath's portfolio pages including case studies, about, and contact information.",
       "url": "https://www.pratyum.xyz/",
-      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      "sha256": "dfcfd6292a0c06961d0bba8a39c26bf97df2f44fe97414d9cc15d3e251bd32a9"
     },
     {
       "name": "read-case-studies",
       "type": "read",
       "description": "Access detailed project case studies and portfolio work.",
       "url": "https://www.pratyum.xyz/cases",
-      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      "sha256": "7f04f6d8e052ec11af3875620a7c7c13bf993d3e8517e0cbf9d574e007d71e19"
     },
     {
       "name": "fetch-rss-feed",
       "type": "read",
       "description": "Fetch the RSS feed of portfolio updates in application/rss+xml format.",
       "url": "https://www.pratyum.xyz/feed.xml",
-      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      "sha256": "dffae199a3283ca0655c3e7cb0c469cfbf4ec55b71acc2932691f9b1fae5f083"
     },
     {
       "name": "fetch-markdown",
       "type": "read",
       "description": "Fetch any portfolio page as Markdown by sending Accept: text/markdown in the request header.",
       "url": "https://www.pratyum.xyz/api/markdown",
-      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      "sha256": "d0cf96f113799c5d151ba2a4ba1c79ca7b503442bee158001c74da9e3eb815ea"
     }
   ]
 }

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://agentskills.io/schemas/v0.2.0/index.json",
+  "skills": [
+    {
+      "name": "browse-portfolio",
+      "type": "read",
+      "description": "Browse Pratyum Jagannath's portfolio pages including case studies, about, and contact information.",
+      "url": "https://www.pratyum.xyz/",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "name": "read-case-studies",
+      "type": "read",
+      "description": "Access detailed project case studies and portfolio work.",
+      "url": "https://www.pratyum.xyz/cases",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "name": "fetch-rss-feed",
+      "type": "read",
+      "description": "Fetch the RSS feed of portfolio updates in application/rss+xml format.",
+      "url": "https://www.pratyum.xyz/feed.xml",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "name": "fetch-markdown",
+      "type": "read",
+      "description": "Fetch any portfolio page as Markdown by sending Accept: text/markdown in the request header.",
+      "url": "https://www.pratyum.xyz/api/markdown",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    }
+  ]
+}

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://modelcontextprotocol.io/schemas/server-card.json",
+  "serverInfo": {
+    "name": "pratyum-xyz",
+    "version": "1.0.0",
+    "description": "MCP server for the Pratyum Jagannath portfolio site"
+  },
+  "transport": {
+    "type": "http",
+    "endpoint": "https://www.pratyum.xyz/api/mcp"
+  },
+  "capabilities": {
+    "tools": true,
+    "resources": true,
+    "prompts": false
+  },
+  "resources": [
+    {
+      "uri": "https://www.pratyum.xyz/",
+      "name": "Homepage",
+      "description": "Pratyum Jagannath's portfolio homepage",
+      "mimeType": "text/html"
+    },
+    {
+      "uri": "https://www.pratyum.xyz/cases",
+      "name": "Case Studies",
+      "description": "Project case studies and portfolio work",
+      "mimeType": "text/html"
+    },
+    {
+      "uri": "https://www.pratyum.xyz/about",
+      "name": "About",
+      "description": "About Pratyum Jagannath",
+      "mimeType": "text/html"
+    },
+    {
+      "uri": "https://www.pratyum.xyz/feed.xml",
+      "name": "RSS Feed",
+      "description": "RSS feed of portfolio updates",
+      "mimeType": "application/rss+xml"
+    }
+  ],
+  "contact": {
+    "url": "https://www.pratyum.xyz/contact"
+  }
+}

--- a/public/auth.md
+++ b/public/auth.md
@@ -32,4 +32,4 @@ None required for public read access.
 
 ## Contact
 
-For questions about agent access, open an issue at <https://github.com/pratyum> or use the contact form at <https://www.pratyum.xyz/contact>.
+For questions about agent access, open an issue at <https://github.com/Pratyum/pratyum-resume-v3/issues> or use the contact form at <https://www.pratyum.xyz/contact>.

--- a/public/auth.md
+++ b/public/auth.md
@@ -1,0 +1,35 @@
+# Auth.md — Agent Registration for pratyum.xyz
+
+This site is the personal portfolio of Pratyum Jagannath. There are no user accounts or commercial APIs. Agent access is fully open and read-only.
+
+## Agent Registration
+
+No registration is required to access publicly available content.
+
+## Identity Types Supported
+
+- `anonymous` — all public endpoints are accessible without authentication
+
+## Credential Types
+
+None required for public read access.
+
+## OAuth / OIDC Discovery
+
+- OpenID Configuration: <https://www.pratyum.xyz/.well-known/openid-configuration>
+- Protected Resource Metadata: <https://www.pratyum.xyz/.well-known/oauth-protected-resource>
+
+## Endpoints Accessible Without Authentication
+
+- `GET /` — Homepage
+- `GET /about` — About page
+- `GET /cases` — Case studies
+- `GET /contact` — Contact page
+- `GET /feed.xml` — RSS feed
+- `GET /.well-known/api-catalog` — API catalog (RFC 9727)
+- `GET /.well-known/agent-skills/index.json` — Agent skills index
+- `GET /.well-known/mcp/server-card.json` — MCP server card
+
+## Contact
+
+For questions about agent access, open an issue at <https://github.com/pratyum> or use the contact form at <https://www.pratyum.xyz/contact>.

--- a/public/auth.md
+++ b/public/auth.md
@@ -17,7 +17,21 @@ None required for public read access.
 ## OAuth / OIDC Discovery
 
 - OpenID Configuration: <https://www.pratyum.xyz/.well-known/openid-configuration>
+- Authorization Server Metadata: <https://www.pratyum.xyz/.well-known/oauth-authorization-server>
 - Protected Resource Metadata: <https://www.pratyum.xyz/.well-known/oauth-protected-resource>
+
+## agent_auth
+
+```json
+{
+  "register_uri": null,
+  "identity_types": ["anonymous"],
+  "credential_types": ["none"],
+  "claim_uri": null,
+  "revocation_uri": null,
+  "note": "All public endpoints are accessible without registration or credentials."
+}
+```
 
 ## Endpoints Accessible Without Authentication
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,10 @@
+# robots.txt for pratyum.xyz
+# https://www.rfc-editor.org/rfc/rfc9309
+
+User-agent: *
+Allow: /
+Allow: /.well-known/
+Disallow: /api/
+Disallow: /_next/
+
+Sitemap: https://www.pratyum.xyz/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -9,6 +9,11 @@ Disallow: /_next/
 
 Sitemap: https://www.pratyum.xyz/sitemap.xml
 
+# ---- Content Signals (draft-romm-aipref-contentsignals) ----
+# https://contentsignals.org/
+# Indexing and agent input are welcome; training on content is not.
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+
 # ---- AI crawler rules ----
 # All AI crawlers are welcome to index public pages.
 # Training on site content is opt-out (see Content-Signal below).

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,3 +8,42 @@ Disallow: /api/
 Disallow: /_next/
 
 Sitemap: https://www.pratyum.xyz/sitemap.xml
+
+# ---- AI crawler rules ----
+# All AI crawlers are welcome to index public pages.
+# Training on site content is opt-out (see Content-Signal below).
+
+User-agent: GPTBot
+Allow: /
+Allow: /.well-known/
+Disallow: /api/
+
+User-agent: OAI-SearchBot
+Allow: /
+Allow: /.well-known/
+Disallow: /api/
+
+User-agent: Claude-Web
+Allow: /
+Allow: /.well-known/
+Disallow: /api/
+
+User-agent: Google-Extended
+Allow: /
+Allow: /.well-known/
+Disallow: /api/
+
+User-agent: PerplexityBot
+Allow: /
+Allow: /.well-known/
+Disallow: /api/
+
+User-agent: Applebot-Extended
+Allow: /
+Allow: /.well-known/
+Disallow: /api/
+
+User-agent: Bytespider
+Allow: /
+Allow: /.well-known/
+Disallow: /api/


### PR DESCRIPTION
## Summary

Implements 10 agent discovery standards so AI agents can programmatically discover and interact with pratyum.xyz. Each goal is a separate, self-contained commit.

## Changes

| # | Goal | Files |
|---|------|-------|
| 1 | **Link headers (RFC 8288)** | `next.config.mjs` — adds `Link` response header on `/` pointing agents to the api-catalog, agent-skills index, MCP server card, and auth.md |
| 2 | **DNS-AID reference** | `config/dns-aid.json` — documents SVCB/HTTPS DNS records that must be published at `_agents.pratyum.xyz` via the DNS provider |
| 3 | **Markdown for Agents** | `middleware.js` + `app/api/markdown/route.js` — rewrites requests with `Accept: text/markdown` to a route that returns `Content-Type: text/markdown` with `Vary: Accept` |
| 4 | **API Catalog (RFC 9727)** | `app/.well-known/api-catalog/route.js` — serves `application/linkset+json` with linkset entries; also adds `/api/health` |
| 5 | **OAuth/OIDC discovery** | `app/.well-known/openid-configuration/route.js` — OpenID Connect discovery document per RFC 8414 |
| 6 | **OAuth Protected Resource** | `app/.well-known/oauth-protected-resource/route.js` — RFC 9728 metadata linking back to the OIDC issuer |
| 7 | **Auth.md** | `public/auth.md` — agent registration instructions, supported identity types, and list of public endpoints |
| 8 | **MCP Server Card (SEP-1649)** | `public/.well-known/mcp/server-card.json` — serverInfo, transport endpoint, capabilities, and resource list |
| 9 | **Agent Skills Index** | `public/.well-known/agent-skills/index.json` — RFC v0.2.0 index with 4 skill entries (browse, case studies, RSS, markdown) |
| 10 | **WebMCP** | `components/WebMCP.js` + `app/layout.js` — calls `navigator.modelContext.provideContext()` with 3 browser tools on every page load |

## Reviewer Notes

- **DNS-AID (Goal 2)** requires manual DNS configuration at the registrar — the JSON file in `config/` is a reference only.
- OAuth/OIDC endpoints (Goals 5 & 6) are stubs appropriate for a public read-only portfolio; no auth infrastructure is wired behind them.
- WebMCP (Goal 10) degrades gracefully — `navigator.modelContext` check prevents errors in browsers that don't implement the API yet.
- All well-known static files in `public/` are served by Next.js's default static file handling; route handlers under `app/.well-known/` are used where a specific `Content-Type` (e.g. `application/linkset+json`) is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled secure agent and AI system access with OpenID Connect and OAuth support
  * Added API health monitoring for system reliability
  * Registered portfolio browsing and content-fetching tools for autonomous systems
  * Implemented Model Context Protocol support for intelligent tool integration

* **Documentation**
  * Added authentication guide explaining access policies

* **Chores**
  * Added infrastructure configuration for agent discovery mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->